### PR TITLE
Update Format.php

### DIFF
--- a/objects/Format.php
+++ b/objects/Format.php
@@ -273,12 +273,12 @@ res{$value}/index.m3u8
             // create command
             
             $command = 'ffmpeg -i {$pathFileName} ';
-            $command .= ' -c:a aac -c:v libx264 -vf scale=-2:240 -g 48 -keyint_min 48  -sc_threshold 0 -bf 3 -b_strategy 2 -b:v '.(300).'k -maxrate '.(450).'k -bufsize '.(600).'k -b:a 128k -f hls -hls_time 15 -hls_list_size 0 -hls_key_info_file {$destinationFile}keyinfo {$destinationFile}res240/index.m3u8';
+            $command .= ' -c:v h264 -vf scale=-2:240 -r 24 -g 48 -keyint_min 48 -sc_threshold 0 -bf 3 -b_strategy 2 -minrate '.(200).'k -crf 23 -maxrate '.(450).'k -bufsize '.(600).'k -c:a aac -b:a 128k -f hls -hls_time 15 -hls_list_size 0 -hls_key_info_file {$destinationFile}keyinfo {$destinationFile}res240/index.m3u8';
             
             foreach ($resolutions as $key => $value) {
                 if ($height >= $value) {
                     $rate = $bandwidth[$key]/1000;
-                    $command .= ' -c:a aac -c:v libx264 -vf scale=-2:'.$value.' -g 48 -keyint_min 48  -sc_threshold 0 -bf 3 -b_strategy 2 -b:v '.($rate).'k -maxrate '.($rate*1.5).'k -bufsize '.($rate*2).'k -b:a '.($audioBitrate[$key]).'k -f hls -hls_time 15 -hls_list_size 0 -hls_key_info_file {$destinationFile}keyinfo {$destinationFile}res'.$value.'/index.m3u8';
+                    $command .= ' -c:v h264 -vf scale=-2:'.$value.' -sc_threshold 0 -bf 3 -b_strategy 2 -minrate '.($rate*0.5).'k -crf 23 -maxrate '.($rate*1.5).'k -bufsize '.($rate*2).'k -c:a aac -b:a '.($audioBitrate[$key]).'k -f hls -hls_time 15 -hls_list_size 0 -hls_key_info_file {$destinationFile}keyinfo {$destinationFile}res'.$value.'/index.m3u8';
                 }
             }
             


### PR DESCRIPTION
// The -g flag should be removed ( it's to indicate frames interval ) , indicating -g 48 flag only if all videos are 24FPS
// Better to leave it empty and let FFMPEG decide . Same goes to `-keyint_min` .

If not then you could create a string on the script to detect the video frame-rate , giving you idea and example 
`$framerates = array(20, 24, 30, 48, 60); `// the commune frame-rates of the videos nowaday

Then on the ffmpeg command line on the script adding this lane 
..........        `-x264opts keyint='.($framerates*2).':no-scenecut -g '.($framerates*2).'`   ............

( sadly I don't have the knowledge to do so )
// `-b:v '.($rate).'k` should be removed , since some original bitrate videos has lower bitrate then output
You could see on the people's issues . When uploading a video of 100mb , after encoding ended up with 300 
Some videos has passive scenes ( no much frames changes ) , meaning no bit-rate needed . Indicating bitrate , we're forcing duplication of frames at a specific high bitrate , but not needed
// to fix this we give a minimum rate and maximum rate . We can leave empty `-b:v` or use `-crf` ; empty means `-crf 23`
The minrate will be the minimum bitrate , and maxrate will be the maximum bitrate of the video . 
`-crf 23` will be based on quality and not bitate , but closed between minrate and maxrate .