### PR TITLE
Optimized transfer for CreateSpirits

### DIFF
--- a/objects/createSpiritsFromVideo.php
+++ b/objects/createSpiritsFromVideo.php
@@ -33,7 +33,7 @@ $height = $tileHeight + $pxBetweenTiles;
 $mapWidth = ($tileWidth + $pxBetweenTiles) * 10;
 $mapHeight = $tileHeight * (ceil($numberOfTiles / 10));
 
-$cmd = "ffmpeg -i \"{$url}\" -vf fps=1/{$step} -s {$tileWidth}x{$tileHeight} {$dirname}out%03d.png";
+$cmd = "ffmpeg -i \"{$url}\" -map 0:v:0 -vf fps=1/{$step} -s {$tileWidth}x{$tileHeight} {$dirname}out%03d.png";
 error_log("CreateSpirits: $cmd");
 //var_dump($duration, $videoLength);echo $cmd;exit;
 exec($cmd);


### PR DESCRIPTION
The `-map p:0` was not the solution for this problem , and not about the mp4 video . But ffmpeg could not select the quality since we're using other flags and mixing resolutions .

Took me 2h to figure out this `-map 0:v:0` one . Not always ffmpeg documentation is easy to understand .

PS: Does work with MP4 ( and very fast delivery for HLS ) , without quality drop