### PR TITLE
docker: fix JPEG configure flag in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ MAINTAINER TheAssassin <theassassin@assassinate-you.net>
 
 RUN apt-get update && \
     apt-get install -y wget git zip default-libmysqlclient-dev libbz2-dev libmemcached-dev libsasl2-dev libfreetype6-dev libicu-dev libjpeg-dev libmemcachedutil2 libpng-dev libxml2-dev mariadb-client ffmpeg libimage-exiftool-perl python curl python-pip libzip-dev libonig-dev && \
-    docker-php-ext-configure gd --with-freetype=/usr/include --with-jpegc=/usr/include && \
+    docker-php-ext-configure gd --with-freetype=/usr/include --with-jpeg=/usr/include && \
     docker-php-ext-install -j$(nproc) bcmath bz2 calendar exif gd gettext iconv intl mbstring mysqli opcache pdo_mysql zip && \
     rm -rf /tmp/* /var/lib/apt/lists/* /var/tmp/* /root/.cache && \
     a2enmod rewrite


### PR DESCRIPTION
This fixes a typo in the `--with-jpeg` configure flag in the Dockerfile.

Closes: #285
