### PR TITLE
Enable concurent encoding processing

### DIFF
--- a/install/checkConfiguration.php
+++ b/install/checkConfiguration.php
@@ -111,6 +111,7 @@ $content = "<?php
 \$global['disableBulkEncode'] = false;
 \$global['disableImportVideo'] = false;
 \$global['disableWebM'] = false;
+\$global['concurrent'] = 1;
 
 \$mysqlHost = '{$_POST['databaseHost']}';
 \$mysqlUser = '{$_POST['databaseUser']}';

--- a/objects/Encoder.php
+++ b/objects/Encoder.php
@@ -428,38 +428,34 @@ class Encoder extends ObjectYPT {
         return $return;
     }
 
-    static function isEncoding() {
+    static function areEncoding() {
         global $global;
+        $i = 0;
         $sql = "SELECT f.*, e.* FROM  " . static::getTableName() . " e "
-                . " LEFT JOIN formats f ON f.id = formats_id WHERE status = 'encoding' OR  status = 'downloading' LIMIT 1 ";
+                . " LEFT JOIN formats f ON f.id = formats_id WHERE status = 'encoding' OR  status = 'downloading' ORDER BY priority ASC, e.id ASC ";
 
         $res = $global['mysqli']->query($sql);
 
-        $sql .= " ORDER BY priority ASC, e.id ASC LIMIT 1";
-
         if ($res) {
-            $result = $res->fetch_assoc();
-            if (!empty($result)) {
+            while ($result = $res->fetch_assoc()) {
                 $encoder = new Encoder($result['id']);
                 if (!$encoder->isWorkerRunning()) {
                     $encoder->setStatus("queue");
                     $encoder->setStatus_obs("Worker died");
                     $encoder->setWorker_pid(NULL);
                     $encoder->save();
-                    return false;
+                    continue;
                 }
                 $result['return_vars'] = json_decode($result['return_vars']);
                 $s = new Streamer($result['streamers_id']);
                 $result['streamer_site'] = $s->getSiteURL();
                 $result['streamer_priority'] = $s->getPriority();
-                return $result;
-            } else {
-                return false;
+                $results[$i++] = $result;
             }
         } else {
             die($sql . '\nError : (' . $global['mysqli']->errno . ') ' . $global['mysqli']->error);
         }
-        return false;
+        return $results;
     }
 
     /*
@@ -548,13 +544,15 @@ class Encoder extends ObjectYPT {
     }
 
     static function run($try = 0) {
+        global $global;
+        $concurrent = isset($global['concurrent']) ? $global['concurrent'] : 1;
         $try++;
         $obj = new stdClass();
         $obj->error = true;
         // check if is encoding something
         //error_log("run($try)");
-        $row = static::isEncoding();
-        if (empty($row['id'])) {
+        $rows = static::areEncoding();
+        if (count($rows) < $concurrent) {
             $row = static::getNext();
             if (empty($row)) {
                 $obj->msg = "There is no file on queue";
@@ -641,7 +639,15 @@ class Encoder extends ObjectYPT {
                 static::run();
             }
         } else {
-            $obj->msg = "The file [{$row['id']}] {$row['filename']} is encoding";
+            $msg = (count($rows) == 1) ? "The file " : "The files ";
+            for ($i = 0; $i < count($rows); $i++) {
+                $row = $rows[$i];
+                $msg .= "[{$row['id']}] {$row['filename']}";
+                if (count($rows) > 1 && $i < count($rows) - 1)
+                    $msg .= ", ";
+            }
+            $msg .= (count($rows) == 1) ? " is encoding" : " are encoding";
+            $obj->msg = $msg;
         }
         return $obj;
     }

--- a/view/index.php
+++ b/view/index.php
@@ -443,7 +443,7 @@ if (!empty($_GET['noNavbar'])) {
                 </div>
 
                 <script>
-                    var encodingNowId = "";
+                    var encodingNowIds = new Array();
                     function checkFiles() {
                         var path = $('#path').val();
                         if (!path) {
@@ -480,53 +480,62 @@ if (!empty($_GET['noNavbar'])) {
                                     }
 
                                 }
-                                if (response.encoding) {
-                                    var id = response.encoding.id;
-                                    // if start encode next before get 100%
-                                    if (id !== encodingNowId) {
-                                        $("#encodeProgress" + encodingNowId).slideUp("normal", function () {
-                                            $(this).remove();
-                                        });
-                                        encodingNowId = id;
+                                if (response.encoding.length > 0) {
+                                    var newEncodingNowIds = new Array();
+                                    for (i = 0; i < response.encoding.length; i++) {
+                                        var id = response.encoding[i].id; 
+                                        newEncodingNowIds.push(id);
                                     }
 
-                                    $("#downloadProgress" + id).slideDown();
-
-                                    if (response.download_status && !response.encoding_status.progress) {
-                                        $("#encodingProgress" + id).find('.progress-completed').html("<strong>" + response.encoding.name + " [Downloading ...] </strong> " + response.download_status.progress + '%');
-                                    } else {
-                                        $("#encodingProgress" + id).find('.progress-completed').html("<strong>" + response.encoding.name + " [" + response.encoding_status.from + " to " + response.encoding_status.to + "] </strong> " + response.encoding_status.progress + '%');
-                                        $("#encodingProgress" + id).find('.progress-bar').css({'width': response.encoding_status.progress + '%'});
-                                    }
-                                    if (response.download_status) {
-                                        $("#downloadProgress" + id).find('.progress-bar').css({'width': response.download_status.progress + '%'});
-                                    }
-                                    if (response.encoding_status.progress >= 100) {
-                                        $("#encodingProgress" + id).find('.progress-bar').css({'width': '100%'});
-                                        setTimeout(function () {
-                                            $("#encodeProgress" + id).fadeOut("slow", function () {
+                                    for (i = 0; i < encodingNowIds.length; i++) {
+                                        var id = encodingNowIds[i]; 
+                                        // if start encode next before get 100%
+                                        if (newEncodingNowIds.indexOf(id) == -1) {
+                                            $("#encodeProgress" + id).slideUp("normal", function () {
                                                 $(this).remove();
                                             });
-                                            $("#downloadProgress" + id).slideUp("fast", function () {
-                                                $(this).remove();
-                                            });
-                                        }, 3000);
-                                    } else {
-
+                                        }
                                     }
+                                    encodingNowIds = newEncodingNowIds;
 
+                                    for (i = 0; i < encodingNowIds.length; i++) {
+                                        var id = encodingNowIds[i]; 
+                                        $("#downloadProgress" + id).slideDown();
+
+
+                                        if (response.download_status[i] && !response.encoding_status[i].progress) {
+                                            $("#encodingProgress" + id).find('.progress-completed').html("<strong>" + response.encoding[i].name + " [Downloading ...] </strong> " + response.download_status[i].progress + '%');
+                                        } else {
+                                            $("#encodingProgress" + id).find('.progress-completed').html("<strong>" + response.encoding[i].name + " [" + response.encoding_status[i].from + " to " + response.encoding_status[i].to + "] </strong> " + response.encoding_status[i].progress + '%');
+                                            $("#encodingProgress" + id).find('.progress-bar').css({'width': response.encoding_status[i].progress + '%'});
+                                        }
+                                        if (response.download_status[i]) {
+                                            $("#downloadProgress" + id).find('.progress-bar').css({'width': response.download_status[i].progress + '%'});
+                                        }
+                                        if (response.encoding_status[i].progress >= 100) {
+                                            $("#encodingProgress" + id).find('.progress-bar').css({'width': '100%'});
+                                            setTimeout(function () {
+                                                $("#encodeProgress" + id).fadeOut("slow", function () {
+                                                    $(this).remove();
+                                                });
+                                                $("#downloadProgress" + id).slideUp("fast", function () {
+                                                    $(this).remove();
+                                                });
+                                            }, 3000);
+                                        } else {
+    
+                                        }
+    
+                                    }
                                     setTimeout(function () {
                                         checkProgress();
                                     }, 1000);
-                                } else if (encodingNowId !== "") {
-                                    $("#encodeProgress" + encodingNowId).slideUp("normal", function () {
-                                        $(this).remove();
-                                    });
-                                    encodingNowId = "";
-                                    setTimeout(function () {
-                                        checkProgress();
-                                    }, 5000);
                                 } else {
+                                    while ((id = encodingNowIds.pop()) != null) { 
+                                        $("#encodeProgress" + id).slideUp("normal", function () {
+                                            $(this).remove();
+                                        });
+                                    }
                                     setTimeout(function () {
                                         checkProgress();
                                     }, 5000);

--- a/view/status.php
+++ b/view/status.php
@@ -14,15 +14,15 @@ $obj->queue_list = array();
 $obj->msg = "";
 $obj->encoding = new stdClass();
 $obj->cmd = "";
-$obj->encoding_status = "";
+$obj->encoding_status = array();
 $obj->version = $config->getVersion();
 
-$obj->encoding = Encoder::isEncoding();
+$obj->encoding = Encoder::areEncoding();
 //$obj->transferring = Encoder::isTransferring();
 $obj->queue_list = Encoder::getAllQueue();
 $obj->queue_size = count($obj->queue_list);
 
-if(empty($obj->encoding['id'])){
+if(count($obj->encoding) == 0) {
     if(empty($obj->queue_list)){
         $obj->msg = "There is no file on queue";
     }else{
@@ -31,9 +31,16 @@ if(empty($obj->encoding['id'])){
     }
 }else{
     $obj->is_encoding = true;
-    $obj->encoding_status = Encoder::getVideoConversionStatus($obj->encoding['id']);
-    $obj->download_status = Encoder::getYoutubeDlProgress($obj->encoding['id']);
-    $obj->msg = "The file [{$obj->encoding['id']}] {$obj->encoding['filename']} is encoding";
+    $msg = (count($obj->encoding) == 1) ? "The file " : "The files ";
+    for ($i = 0; $i < count($obj->encoding); $i++) {
+        $obj->encoding_status[$i] = Encoder::getVideoConversionStatus($obj->encoding[$i]['id']);
+        $obj->download_status[$i] = Encoder::getYoutubeDlProgress($obj->encoding[$i]['id']);
+        $msg .= "[{$obj->encoding[$i]['id']}] {$obj->encoding[$i]['filename']}";
+        if (count($obj->encoding) > 1 && $i < count($obj->encoding) - 1)
+            $msg .= ", ";
+    }
+    $msg .= (count($obj->encoding) == 1) ? " is encoding" : " are encoding";
+    $obj->msg = $msg;
 }
 
 if(!empty($_GET['serverStatus'])){


### PR DESCRIPTION
Some systems have a lot of cores, it is a shame to leave them unused.
This changes let AVideo-Encoder perform concurent enconding.

The feature is controlled by global $concurent variable in the
configuration file. If absent, we fallback to 1, which means no
concurency. I experimented with $concurent set to 4 on a 4 core
systems with great benefit. Not all corner cases on status
update have been tested, though.