### PR TITLE
    Send videos to streamer as soon as they are available

### DIFF
--- a/install/checkConfiguration.php
+++ b/install/checkConfiguration.php
@@ -113,6 +113,7 @@ $content = "<?php
 \$global['disableWebM'] = false;
 \$global['concurrent'] = 1;
 \$global['hideUserGroups'] = false;
+\$global['progressiveUpload'] = false;
 
 \$mysqlHost = '{$_POST['databaseHost']}';
 \$mysqlUser = '{$_POST['databaseUser']}';

--- a/install/database.sql
+++ b/install/database.sql
@@ -75,6 +75,25 @@ ENGINE = InnoDB;
 
 
 -- -----------------------------------------------------
+-- Table `upload_queue`
+-- -----------------------------------------------------
+CREATE TABLE IF NOT EXISTS `upload_queue` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `encoders_id` INT NOT NULL,
+  `resolution` VARCHAR(255) NOT NULL,
+  `format` VARCHAR(255) NOT NULL,
+  `videos_id` INT NOT NULL,
+  `status` VARCHAR(45) NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `fk_upload_queue_encoders_idx` (`encoders_id` ASC),
+  CONSTRAINT `fk_upload_queue_encoders`
+    FOREIGN KEY (`encoders_id`)
+    REFERENCES `encoder_queue` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE)
+ENGINE = InnoDB;
+
+-- -----------------------------------------------------
 -- Table `configurations`
 -- -----------------------------------------------------
 CREATE TABLE IF NOT EXISTS `configurations` (

--- a/objects/Encoder.php
+++ b/objects/Encoder.php
@@ -5,6 +5,7 @@ $sentImage = array();
 require_once $global['systemRootPath'] . 'objects/Format.php';
 require_once $global['systemRootPath'] . 'objects/Login.php';
 require_once $global['systemRootPath'] . 'objects/Streamer.php';
+require_once $global['systemRootPath'] . 'objects/Upload.php';
 require_once $global['systemRootPath'] . 'objects/functions.php';
 
 class Encoder extends ObjectYPT {
@@ -866,6 +867,17 @@ class Encoder extends ObjectYPT {
         $obj->resolution = $resolution;
         $obj->videoDownloadedLink = $encoder->getVideoDownloadedLink();
 
+        if ($global['progressiveUpload'] == true && isset($encoder)) {
+            $u = Upload::loadFromEncoder($encoder->getId(), $resolution, $forma
+);
+            if ($u !== false && $u->getStatus() == "done") {
+                $obj->error = false;
+                $obj->msg = "Already sent";
+                error_log("Encoder::sendFile already sent videos_id=$videos_id, format=$format");
+                return $obj;
+            }
+        }
+
         error_log("Encoder::sendFile videos_id=$videos_id, format=$format");
         if(empty($duration)){
             $duration = static::getDurationFromFile($file);
@@ -962,6 +974,11 @@ class Encoder extends ObjectYPT {
         error_log(json_encode($obj));
         $encoder->setReturn_varsVideos_id($obj->response->video_id);
         //var_dump($obj);exit;
+
+        if (isset($u) && $u !== false && $obj->error == false) {
+            $u->setStatus("done");
+            $u->save(); 
+        }
         return $obj;
     }
 
@@ -1472,6 +1489,10 @@ class Encoder extends ObjectYPT {
             }
         }
         $this->deleteOriginal();
+
+        if ($global['progressiveUpload'] == true)
+            Upload::deleteFile($this->id);
+
         return parent::delete();
     }
 

--- a/objects/Format.php
+++ b/objects/Format.php
@@ -4,6 +4,9 @@ if (!class_exists('Format')) {
     if (!class_exists('ObjectYPT')) {
         require_once 'Object.php';
     }
+    if(!class_exists('Upload')){
+        require_once 'Upload.php';
+    }
 
     class Format extends ObjectYPT {
 
@@ -112,6 +115,9 @@ if (!class_exists('Format')) {
                     $obj = static::execOrder(20, $pathFileName, $destination, $encoder_queue_id);
                 }
             }
+
+            if ($global['progressiveUpload'] == true)
+                Upload::create($encoder_queue_id, $destinationFile);
 
             return $obj;
         }

--- a/objects/Upload.php
+++ b/objects/Upload.php
@@ -1,0 +1,132 @@
+<?php
+
+require_once $global['systemRootPath'] . 'objects/Encoder.php';
+require_once $global['systemRootPath'] . 'objects/Login.php';
+require_once $global['systemRootPath'] . 'objects/Streamer.php';
+require_once $global['systemRootPath'] . 'objects/functions.php';
+
+class Upload extends ObjectYPT {
+
+    protected $id, $encoders_id, $resolution, $format, $videos_id, $status;
+
+    static function getTableName() {
+        return 'upload_queue';
+    }
+
+    static function getSearchFieldsNames() {
+        return array();
+    }
+
+    static function loadFromEncoder($encoders_id, $resolution, $format) {
+fprintf(fopen("/tmp/log", "a"), "loadFromEncoder(%d, %s, %s)\n%s\n", $encoders_id, $resolution, $format, print_r(debug_backtrace(), true));
+        global $global;
+        $sql = "SELECT * FROM " . static::getTableName() . " WHERE  `encoders_id` = $encoders_id AND `resolution` = '$resolution' AND `format`= '$format' LIMIT 1";
+        $global['lastQuery'] = $sql;
+        $res = $global['mysqli']->query($sql);
+        if ($res === false)
+            return false;
+
+        $row = $res->fetch_assoc();
+        if (empty($row['id']))
+            return false;
+
+        $u = new Upload($row['id']);
+        foreach ($row as $key => $value)
+            $u->$key = $value;
+
+        return $u;
+    }
+
+   static function create($encoders_id, $file) {
+fprintf(fopen("/tmp/log", "a"), "create(%d, %s)\n%s\n", $encoders_id, $file, print_r(debug_backtrace(), true));
+       preg_match("/tmpFile_converted_([^.]+)\.(.*)$/", $file, $matches);
+       if (empty($matches[1]) || empty($matches[2])) {
+           error_log("Upload::createIfNotExists filename ".$file." not match");
+           return false;
+       }
+
+       $resolution = $matches[1];
+       $format = $matches[2];
+ 
+       $e = new Encoder($encoders_id);
+       $return_vars = json_decode($e->getReturn_vars());
+       if (empty($return_vars->videos_id)) {
+           error_log("Upload::createIfNotExists no videos_id");
+           return false;
+       }
+ 
+       $u = new Upload("");
+       $u->setEncoders_id($encoders_id);
+       $u->setResolution($resolution);
+       $u->setFormat($format);
+       $u->setVideos_id($return_vars->videos_id);
+       $u->setStatus("queue");
+       $u->save();
+
+       $sent = Encoder::sendFile($file, $return_vars->videos_id, $format, $e, $resolution);
+
+       return $u;
+   }   
+
+    static function deleteFile($encoders_id) {
+        global $global;
+
+        $sql = "SELECT * FROM " . static::getTableName() . " WHERE  `encoders_id` = $encoders_id";
+        $global['lastQuery'] = $sql;
+        $res = $global['mysqli']->query($sql);
+        if ($res === false)
+            return false;
+
+        while ($row = $res->fetch_assoc()) {
+            $u = new Upload($row['id']);
+            $u->delete();
+        }
+
+        return true;
+    }
+
+    function getId() {
+        return $this->id;
+    }
+
+    function getEncoder_id() {
+        return $this->encoders_id;
+    }
+
+    function getResolution() {
+        return $this->resolution;
+    }
+
+    function getFormat() {
+        return $this->format;
+    }
+
+    function getVideos_id() {
+        return $this->videos_id;
+    }
+
+    function getStatus() {
+        return $this->status;
+    }
+
+    function setEncoders_id($encoders_id) {
+        $this->encoders_id = $encoders_id;
+    }
+
+    function setResolution($resolution) {
+        $this->resolution = $resolution;
+    }
+
+    function setFormat($format) {
+        $this->format = $format;
+    }
+
+    function setVideos_id($videos_id) {
+        $this->videos_id = $videos_id;
+    }
+
+    function setStatus($status) {
+        $this->status = $status;
+    }
+
+}

--- a/objects/Upload.php
+++ b/objects/Upload.php
@@ -18,7 +18,6 @@ class Upload extends ObjectYPT {
     }
 
     static function loadFromEncoder($encoders_id, $resolution, $format) {
-fprintf(fopen("/tmp/log", "a"), "loadFromEncoder(%d, %s, %s)\n%s\n", $encoders_id, $resolution, $format, print_r(debug_backtrace(), true));
         global $global;
         $sql = "SELECT * FROM " . static::getTableName() . " WHERE  `encoders_id` = $encoders_id AND `resolution` = '$resolution' AND `format`= '$format' LIMIT 1";
         $global['lastQuery'] = $sql;
@@ -38,7 +37,6 @@ fprintf(fopen("/tmp/log", "a"), "loadFromEncoder(%d, %s, %s)\n%s\n", $encoders_i
     }
 
    static function create($encoders_id, $file) {
-fprintf(fopen("/tmp/log", "a"), "create(%d, %s)\n%s\n", $encoders_id, $file, print_r(debug_backtrace(), true));
        preg_match("/tmpFile_converted_([^.]+)\.(.*)$/", $file, $matches);
        if (empty($matches[1]) || empty($matches[2])) {
            error_log("Upload::createIfNotExists filename ".$file." not match");

--- a/update/updateDb.v3.4.sql
+++ b/update/updateDb.v3.4.sql
@@ -7,6 +7,22 @@ ALTER TABLE `encoder_queue`
 ADD COLUMN `worker_pid` INT NULL;
 
 
+CREATE TABLE IF NOT EXISTS `upload_queue` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `encoders_id` INT NOT NULL,
+  `resolution` VARCHAR(255) NOT NULL,
+  `format` VARCHAR(255) NOT NULL,
+  `videos_id` INT NOT NULL,
+  `status` VARCHAR(45) NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `fk_upload_queue_encoders_idx` (`encoders_id` ASC),
+  CONSTRAINT `fk_upload_queue_encoders`
+    FOREIGN KEY (`encoders_id`)
+    REFERENCES `encoder_queue` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE)
+ENGINE = InnoDB;
+
 
 SET SQL_MODE=@OLD_SQL_MODE;
 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;

--- a/update/updateDb.v3.5.sql
+++ b/update/updateDb.v3.5.sql
@@ -1,0 +1,27 @@
+SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0;
+SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0;
+SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='TRADITIONAL,ALLOW_INVALID_DATES';
+
+
+CREATE TABLE IF NOT EXISTS `upload_queue` (
+  `id` INT NOT NULL AUTO_INCREMENT,
+  `encoders_id` INT NOT NULL,
+  `resolution` VARCHAR(255) NOT NULL,
+  `format` VARCHAR(255) NOT NULL,
+  `videos_id` INT NOT NULL,
+  `status` VARCHAR(45) NOT NULL,
+  PRIMARY KEY (`id`),
+  INDEX `fk_upload_queue_encoders_idx` (`encoders_id` ASC),
+  CONSTRAINT `fk_upload_queue_encoders`
+    FOREIGN KEY (`encoders_id`)
+    REFERENCES `encoder_queue` (`id`)
+    ON DELETE CASCADE
+    ON UPDATE CASCADE)
+ENGINE = InnoDB;
+
+
+SET SQL_MODE=@OLD_SQL_MODE;
+SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS;
+SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS;
+-- support for the chunked transfer between servers
+UPDATE configurations SET  version = '3.5', modified = now() WHERE id = 1;


### PR DESCRIPTION
    Send videos to streamer as soon as they are available
    
    This change introduce a global option progressiveUpload so that
    multi resolution runs send videos to the streamer as soon as they
    have been individually encoded, instead of waiting for all of
    them to be encoded.
    
    I introduced an Upload class and a upload_queue database table
    to keep track of what uploads have been done, so that the normal
    process of sending all encoded videos can take over if a transfer
    failed, while avoiding to send again the same file. This part may
    be over-engineered, a global array may have been enough, thought it
    would not have covered the situation where we resume encoding after
    a crash.
