### PR TITLE
Send original video immediatly when progressiveUpload is enabled

### DIFF
--- a/view/upload.php
+++ b/view/upload.php
@@ -105,6 +105,10 @@ if (isset($_FILES['upl']) && $_FILES['upl']['error'] == 0) {
         }
         $e->setReturn_vars(json_encode($obj));
 
+        if ($global['progressiveUpload'] == true) {
+            Encoder::sendFile($destinationFile, $obj->videos_id, $format, $e, 'HD');
+        }
+
         $encoders_ids[] = $e->save();
 
         $obj->error = false;


### PR DESCRIPTION
This will make the mp4_HD (or webm_HD) immediatly available in
AVideo, before it is overwritten by the mp4_HD from encoding.