### PR TITLE
Rollback unused change for progressive upload

### DIFF
--- a/objects/Encoder.php
+++ b/objects/Encoder.php
@@ -856,12 +856,9 @@ class Encoder extends ObjectYPT {
         return $return;
     }
 
-    static function sendFile($file, $videos_id, $format, $encoder = null, $resolution = "", $chunkFile = "", $duration = "", $keep_encoding = null) {
+    static function sendFile($file, $videos_id, $format, $encoder = null, $resolution = "", $chunkFile = "", $duration = "") {
         global $global;
         global $sentImage;
-
-        if (!isset($keep_encoding))
-            $keep_encoding = ($global['progressiveUpload'] == true);
 
         $obj = new stdClass();
         $obj->error = true;
@@ -915,6 +912,8 @@ class Encoder extends ObjectYPT {
         $aVideoURL = $s->getSiteURL();
         $user = $s->getUser();
         $pass = $s->getPass();
+
+        $keep_encoding = ($global['progressiveUpload'] == true);
 
         $target = trim($aVideoURL . "aVideoEncoder.json");
         $obj->target = $target;
@@ -1495,11 +1494,6 @@ class Encoder extends ObjectYPT {
         $this->deleteOriginal();
 
         if ($global['progressiveUpload'] == true) {
-            // telll avideo there is no more encoding left
-            $return_vars = json_decode($this->getReturn_vars());
-            if (!empty($return_vars->videos_id))
-                static::sendFile("", $return_vars->videos_id, "", $this, false);
-
             Upload::deleteFile($this->id);
         }
 


### PR DESCRIPTION
When progressiveUpload is enabled, we send files with keepEncoding=1
POST paramter so that AVideo knows there are more videos to come,
and status should be k (active and encoding) instead of a (active).

I first planned to sendFile without a file at Encoder::delete() time
without keepEncoding=1 so that AVideo knows the video upload is over
and switch status to a. There was a bug (one missing parameter in
Encoder::sendFile(),  call) that caused it to be nilpotent, but the
behavior was still correct because Encoder:notifyVideoIsDone() also
causes to change the video status to a.

The logic to notify AVideo from Encoder::delete() by calling
Encoder:sendFile() without a file is therefore useless. This
patch removes it for the sake of code readability.