### PR TITLE
Improve worker tracking code

### DIFF
--- a/objects/Encoder.php
+++ b/objects/Encoder.php
@@ -135,7 +135,7 @@ class Encoder extends ObjectYPT {
         case "downloading":
         case "encoding":
         case "packing":
-        case "transfering":
+        case "transferring":
         default:
             $this->setWorker_pid(getmypid());
             break;


### PR DESCRIPTION
Instead of calling setWorker_pid() each time we call setStatus(), wrap
setWorker_pid() inside setStatus(). That makes the code easier to read,
and it removes any opportuny to forget about it.