### PR TITLE
Erratum from pull request 351

### DIFF
--- a/objects/Encoder.php
+++ b/objects/Encoder.php
@@ -994,7 +994,7 @@ class Encoder extends ObjectYPT {
         error_log("Encoder::sendFile videos_id=$videos_id, format=$format");
 
         $duration = static::getDurationFromFile($file);
-        if ($duration == "EE:EE:EE") {
+        if ($duration == "EE:EE:EE" && $file != "") {
             if (isset($u) && $u !== false && $obj->error == false) {
                 $u->setStatus("error");
                 $u->save(); 


### PR DESCRIPTION
When sendFile() checks for sane file duration, make sure we do not
discard the special case where file is "", which is used to initially
create the video in AVideo