### PR TITLE
Add an option to make sure the encoded HD is smaller than origial

### DIFF
--- a/install/checkConfiguration.php
+++ b/install/checkConfiguration.php
@@ -116,6 +116,7 @@ $content = "<?php
 \$global['hideUserGroups'] = false;
 \$global['progressiveUpload'] = false;
 \$global['killWorkerOnDelete'] = false;
+\$global['preferSmallerMaster'] = false;
 
 \$mysqlHost = '{$_POST['databaseHost']}';
 \$mysqlUser = '{$_POST['databaseUser']}';

--- a/objects/Format.php
+++ b/objects/Format.php
@@ -62,7 +62,7 @@ if (!class_exists('Format')) {
                 return true;
             }
 
-            return true;
+            return false;
         }
 
 


### PR DESCRIPTION
This changes adds the preferSmallerMaster option, which checks that the HD encoded video is not bigger than submitted video. If that is the case, the encoded HD is discarded and the original video is used for HD.
