### PR TITLE
Security patch.

### DIFF
--- a/objects/Login.php
+++ b/objects/Login.php
@@ -7,7 +7,13 @@ if (!class_exists('Login')) {
 
     class Login {
 
-        static function run($user, $pass, $aVideoURL, $encodedPass = false) {
+        static function run(
+            $user,
+            #[\SensitiveParameter]
+            $pass,
+            $aVideoURL,
+            $encodedPass = false
+        ) {
             global $_runLogin;
             $index = "$user, $pass, $aVideoURL";
             if (!isset($_runLogin)) {


### PR DESCRIPTION
On PHP versions < 8.2, this change will have no effect.

On PHP versions >= 8.2, this change will *slightly* improve the security of the login process by identifying to PHP that the `$pass` parameter is "sensitive". When the content of a parameter would normally appear in error logs (e.g., when some kind of error occurs, PHP crashes, etc), or when it would normally be displayed via `var_dump();` or similar, if the parameter has been marked as "sensitive", instead of the normal content, something like `Object(SensitiveParameterValue)` would be displayed, helping to reduce the risk of such sensitive content being leaked.

*See: https://www.php.net/manual/en/class.sensitiveparameter.php*

The sensitive parameter attribute isn't available for PHP versions < 8.2. However, for PHP versions < 8.2, when the content of a line in some PHP code begins with a dash (`#`), it is treated the same as a comment (e.g., `// like this`), so, as long as the sensitive parameter attribute is kept on its own line, backwards-compatibility problems should be avoidable (i.e., it won't cause errors, won't cause PHP to crash, etc).