### PR TITLE
Files with UPPER case extensions not listing in bulk upload

### DIFF
--- a/view/listFiles.json.php
+++ b/view/listFiles.json.php
@@ -13,7 +13,10 @@ if(Login::canBulkEncode()){
         //var_dump($path, file_exists($path));
         if (file_exists($path)) {
             if (defined( 'GLOB_BRACE' )) {
-                $filesStr = "{*." . implode(",*.", $global['allowed']) . "}";
+                $extn = implode(",*.", $global['allowed']);
+                $extnLower = strtolower($extn);
+                $extnUpper = strtoupper($extn);
+                $filesStr = "{*." . $extn . ",*" . $extnLower . ",*" . $extnUpper . "}";
                 //var_dump($filesStr);
                 //echo $files;
                 $video_array = glob($path . $filesStr, GLOB_BRACE);


### PR DESCRIPTION
This fix will take the same allowed list to be considered in it's current original case (can be mixed), lower case format and also upper case format. Since it is also possible that some formats are mixed case (Ex: Mov instead of MOV) it is better to take all three cases (though may have duplicates in $fileStr, does not hurt.).