### PR TITLE
Fix issue with bulk encoding of a large number of files

### DIFF
--- a/view/queue.php
+++ b/view/queue.php
@@ -4,6 +4,8 @@ require_once dirname(__FILE__) . '/../videos/configuration.php';
 require_once '../objects/Encoder.php';
 require_once '../objects/Login.php';
 
+session_write_close();
+
 if (empty($_POST['fileURI'])) {
     die("File URI Not found");
 }


### PR DESCRIPTION
The issue was caused by sending multiple XHR requests simultaneously, which led to some requests failing to enqueue files.
I considered the following solutions:
1. Send a single XHR request for all files
2. Send XHR requests sequentially
3. Reduce the scope of the session lock
4. Tune the lock acquisition retry count

This PR implements solution 3. While it mitigates the issue, a complete solution is more complex and will require further changes.

Fix: WWBN/AVideo-Encoder#554

Screenshot:
![Screenshot from 2025-05-01 12-21-07](https://github.com/user-attachments/assets/e9eea57a-7657-43b7-9863-e1bf1ae7849b)
